### PR TITLE
allow for atomic activation of modules without dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Template for module tests initialization is added
 - OxideshopAdmin module with admin frames selection actions
+- OxideshopModules module with just the OXID module activation
 
 ### Fix
 - Improved the waitForAjax method jQuery waiting condition to work with shortened and full jQuery calls

--- a/src/Module/OxidModules.php
+++ b/src/Module/OxidModules.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © OXID eSales AG. All rights reserved.
+ * See LICENSE file for license details.
+ */
+
+namespace OxidEsales\Codeception\Module;
+
+require_once __DIR__.'/../../../../oxid-esales/testing-library/base.php';
+
+use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ModuleSetupException;
+
+/**
+ * Class Oxideshop
+ * @package OxidEsales\Codeception\Module
+ */
+class OxidModules extends \Codeception\Module
+{
+    /**
+     * Reset context and activate modules before test
+     */
+    public function _beforeSuite($settings = [])
+    {
+        $this->activateModules();
+    }
+
+    /**
+     * Activates modules
+     */
+    private function activateModules()
+    {
+        $testConfig = new \OxidEsales\TestingLibrary\TestConfig();
+        $modulesToActivate = $testConfig->getModulesToActivate();
+
+        if ($modulesToActivate) {
+            $serviceCaller = new \OxidEsales\TestingLibrary\ServiceCaller();
+            $serviceCaller->setParameter('modulestoactivate', $modulesToActivate);
+            try {
+                $serviceCaller->callService('ModuleInstaller', 1);
+            } catch (ModuleSetupException $e) {
+                // this may happen if the module is already active,
+                // we can ignore this
+            }
+        }
+    }
+}

--- a/src/Module/OxideshopModules.php
+++ b/src/Module/OxideshopModules.php
@@ -14,7 +14,7 @@ use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ModuleSe
  * Class Oxideshop
  * @package OxidEsales\Codeception\Module
  */
-class OxidModules extends \Codeception\Module
+class OxideshopModules extends \Codeception\Module
 {
     /**
      * Reset context and activate modules before test

--- a/src/Module/OxideshopModules.php
+++ b/src/Module/OxideshopModules.php
@@ -8,14 +8,21 @@ namespace OxidEsales\Codeception\Module;
 
 require_once __DIR__.'/../../../../oxid-esales/testing-library/base.php';
 
+use Codeception\Lib\Interfaces\ConflictsWithModule;
 use OxidEsales\EshopCommunity\Internal\Framework\Module\Setup\Exception\ModuleSetupException;
 
 /**
  * Class Oxideshop
  * @package OxidEsales\Codeception\Module
  */
-class OxideshopModules extends \Codeception\Module
+class OxideshopModules extends \Codeception\Module implements ConflictsWithModule
 {
+
+    public function _conflicts()
+    {
+        return 'OxidEsales\Codeception\Module\Oxideshop';
+    }
+
     /**
      * Reset context and activate modules before test
      */


### PR DESCRIPTION
This pull requests adds a simple `OxideshopModules` codeception module to just allow for activation of the modules specified in the `test_config.yml` without the need to setup a `Db` or `WebDriver` which is not needed in the case you are testing against a JSON-API (in that specific case GraphQL).

If i would use the `Oxideshop` module, i would have to setup a `Db` and `WebDriver` that i don't need.

I would like to further suggest, to remove the OXID module activation from the `Oxideshop` module to make this operation more explicit and atomic.